### PR TITLE
Fix: Replace CSS logo with static image in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,13 +424,7 @@
     <div id="slide1" class="slide title-slide">
         <div class="slide-header">
             <div class="company-logo">
-                <div class="logo-symbol">
-                    <div class="diamond-stack">
-                        <div class="diamond red"></div>
-                        <div class="diamond beige"></div>
-                        <div class="diamond green"></div>
-                    </div>
-                </div>
+                <img src="static/images/sentient-logo.png" style="max-width: 50px; height: auto;" class="logo-symbol" alt="Sentient.io Logo">
                 <span>sentient.io</span>
             </div>
             <div class="slide-number">1</div>


### PR DESCRIPTION
I replaced the CSS-based logo in slide 1 of index.html with an `<img>` tag. The new logo image is sourced from static/images/sentient-logo.png. I added inline styles to ensure the logo is appropriately sized (max-width: 50px, height: auto). The class `logo-symbol` was retained on the new `<img>` tag for consistency if any styles depend on it.