### PR TITLE
Fix: Correctly double the image logo size on Slide 1 of index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,8 @@
         }
 
         .logo-symbol {
-            width: 50px;
-            height: 40px;
+            width: 100px;
+            height: 80px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -424,7 +424,7 @@
     <div id="slide1" class="slide title-slide">
         <div class="slide-header">
             <div class="company-logo">
-                <img src="static/images/sentient-logo.png" style="max-width: 100px; height: auto;" class="logo-symbol" alt="Sentient.io Logo">
+                <img src="static/images/sentient-logo.png" class="logo-symbol" alt="Sentient.io Logo">
                 <span style="font-size: 64px;">sentient.io</span>
             </div>
             <div class="slide-number">1</div>


### PR DESCRIPTION
This commit adjusts the CSS for the `.logo-symbol` class to ensure the image logo on Slide 1 is displayed at the intended doubled size. The previous attempt to use inline styles for `max-width` was overridden by the `width` and `height` properties in the CSS rule.

- Modified the `.logo-symbol` CSS rule in `index.html`:
    - `width` changed from `50px` to `100px`.
    - `height` changed from `40px` to `80px`.
- Removed the redundant inline `style` attribute from the `<img>` tag with `class="logo-symbol"` on Slide 1.

The text logo adjacent to the image, also on Slide 1, was already correctly enlarged in the preceding commit.