### PR TITLE
Docs: Populate V0.2.3 founder slide documents

### DIFF
--- a/plans/1_planning/V0.2.3/README.md
+++ b/plans/1_planning/V0.2.3/README.md
@@ -1,0 +1,17 @@
+# V0.2.3 - Founder Slide Update
+
+**Status**: In Planning
+**Target**: 2025-06-03
+**Type**: Feature Enhancement
+
+## Description
+
+This release focuses on updating the founder slide to include Christopher Yeo's photo.
+
+### Key Tasks:
+- Source and optimize a high-quality headshot of Christopher Yeo.
+- Ensure proper sizing and placement of the photo on the slide.
+- Add professional styling and border to the image.
+- Verify accessibility by adding appropriate alt text to the image.
+
+The image for Christopher Yeo (`chris-yeo.png`) is located in the `static/images/` directory.

--- a/plans/1_planning/V0.2.3/design.md
+++ b/plans/1_planning/V0.2.3/design.md
@@ -1,0 +1,43 @@
+# V0.2.3 - Founder Slide Design
+
+## Overview
+
+This document outlines the design specifications for the founder slide update, focusing on the inclusion of Christopher Yeo's photo.
+
+## Design Details
+
+### 1. Image Sourcing and Optimization
+- **Source**: A high-quality, professional headshot of Christopher Yeo. The existing image `chris-yeo.png` in `static/images/` should be evaluated. If it's not suitable, a new one should be sourced.
+- **Optimization**: The image must be optimized for web use to ensure fast loading times without sacrificing quality. This includes:
+    - Compression (lossless or minimal lossy).
+    - Appropriate file format (e.g., PNG for transparency if needed, otherwise JPEG for photos).
+    - Resizing to the dimensions it will be displayed at.
+
+### 2. Sizing and Placement
+- **Sizing**: The image should be sized appropriately to fit within the existing slide layout. It should be prominent but not overpowering. Specific dimensions will depend on the final slide design, but it should be clear and easily recognizable.
+- **Placement**: The photo should be strategically placed on the founder slide. Common placements include:
+    - Top-left or top-right corner, alongside text.
+    - Centered if it's the main focus of the slide with minimal text.
+    - Integrated into a dedicated "About the Founder" section.
+    - Consistency with other profile images in the presentation (if any) should be maintained.
+
+### 3. Styling and Border
+- **Styling**:
+    - The image should have a clean and professional look.
+    - Consider a subtle shadow or rounded corners if it aligns with the overall presentation aesthetic.
+    - Ensure the styling is consistent with the brand guidelines.
+- **Border**:
+    - A thin, unobtrusive border can be added to frame the photo and make it stand out slightly from the background.
+    - Border color should complement the slide's color scheme.
+
+### 4. Accessibility
+- **Alt Text**: Meaningful alt text must be provided for the image. For example: "Headshot of Christopher Yeo, Founder and CEO of Sentient.io". This is crucial for users with visual impairments using screen readers.
+
+## Mockups/Sketches
+
+*(Placeholder for visual mockups or sketches of the founder slide with the new photo. This section would typically include low-fidelity wireframes or high-fidelity mockups showing the image in context.)*
+
+## Design Considerations
+- **Responsiveness**: Ensure the image and slide layout are responsive and look good on various screen sizes (desktop, tablet, mobile).
+- **Consistency**: The design should be consistent with the overall look and feel of the presentation.
+- **Clarity**: The photo should be clear, well-lit, and professional.

--- a/plans/1_planning/V0.2.3/tech-spec.md
+++ b/plans/1_planning/V0.2.3/tech-spec.md
@@ -1,0 +1,59 @@
+# V0.2.3 - Founder Slide Technical Specifications
+
+## Overview
+
+This document outlines the technical specifications for implementing the founder slide update, specifically the inclusion of Christopher Yeo's photo.
+
+## Technical Requirements
+
+### 1. Image Implementation
+- **HTML**:
+    - The image will be embedded using an `<img>` tag.
+    - The `src` attribute will point to the optimized image file, e.g., `static/images/chris-yeo.png`.
+    - The `alt` attribute must be populated with descriptive text for accessibility (e.g., "Headshot of Christopher Yeo, Founder and CEO of Sentient.io").
+    ```html
+    <img src="static/images/chris-yeo.png" alt="Headshot of Christopher Yeo, Founder and CEO of Sentient.io" class="founder-photo">
+    ```
+- **CSS**:
+    - A dedicated CSS class (e.g., `founder-photo`) will be used to style the image.
+    - Styles will control:
+        - `max-width` and `height: auto` for responsiveness.
+        - Specific `width` and `height` if a fixed size is determined by the design.
+        - `border-radius` for rounded corners, if applicable.
+        - `box-shadow` for shadow effects, if applicable.
+        - `border` for a visible border, if applicable.
+        - `margin` and `padding` for spacing.
+    - Example CSS:
+    ```css
+    .founder-photo {
+      max-width: 200px; /* Example size */
+      height: auto;
+      border-radius: 8px; /* Optional */
+      border: 1px solid #ccc; /* Optional */
+      box-shadow: 2px 2px 5px rgba(0,0,0,0.1); /* Optional */
+    }
+    ```
+- **JavaScript**:
+    - No specific JavaScript is anticipated for the image itself unless dynamic loading or interactive elements (e.g., a modal popup on click) are part of the extended requirements. For V0.2.3, the focus is on static display.
+
+### 2. Slide Structure
+- The existing HTML structure for slides should be used. The new image element will be integrated into the relevant slide's content block.
+- Ensure that the addition of the image does not break the existing slide layout or navigation.
+
+### 3. Performance
+- **Image Optimization**: As specified in the design document, the image must be optimized (compressed, correctly sized) before being added to the `static/images/` directory.
+- **Lazy Loading**: If the presentation contains many images or if initial load time is a concern, consider implementing lazy loading for images that are not immediately visible. However, for a single founder photo, this might be overkill unless it's part of a larger image optimization strategy.
+
+### 4. Responsiveness
+- CSS media queries should be used if necessary to adjust the image size, placement, or styling on different screen sizes (desktop, tablet, mobile).
+- The image should scale gracefully and not distort or overflow its container.
+
+### 5. Accessibility
+- Adherence to WCAG guidelines for images.
+- Ensure the alt text is implemented correctly and provides value to users of assistive technologies.
+
+## Testing Considerations
+- Verify the image displays correctly across major browsers (Chrome, Firefox, Safari, Edge).
+- Test on different devices/screen resolutions to ensure responsiveness.
+- Use a screen reader to check the alt text implementation.
+- Check page load speed to ensure the image is not causing performance issues.


### PR DESCRIPTION
I've populated the README.md, design.md, and tech-spec.md files in the plans/1_planning/V0.2.3 directory.

These documents now contain details for the V0.2.3 feature:
- README.md: Includes the release description and notes that Christopher Yeo's image is in static/images/.
- design.md: Outlines design considerations for sourcing, optimizing, sizing, placing, styling the founder's photo, and ensuring accessibility.
- tech-spec.md: Provides technical specifications for HTML, CSS, and potential JavaScript related to the image implementation, as well as performance and testing considerations.