### PR TITLE
docs: note status table in create_version

### DIFF
--- a/plans/Versions/V0.2.6/create_version.md
+++ b/plans/Versions/V0.2.6/create_version.md
@@ -68,7 +68,7 @@ Each version directory tracks progress through these stages in `TASKS.md`:
 2. **In Progress** (Starts at Phase 3)
 3. **Completed** (After Phase 6)
 
-The status is automatically updated during phase transitions and includes timestamps for each state change.
+The status is automatically updated during phase transitions and includes timestamps for each state change. A central Version Status table in `plans/_reference/CHANGELOG.md` lists all versions and their status—remember to update this table accordingly.
 
 ### Example status section in TASKS.md:
 ```markdown
@@ -597,7 +597,7 @@ Note: Only the files and directories listed in Q1 of code_verification.md should
    - Update status in `TASKS.md` to 'Completed'
    - Finalize all version documentation
    - Update ROADMAP.md with completion status
-   - Generate CHANGELOG.md entry
+   - Update the Version Status table and generate a CHANGELOG.md entry
    - Create release notes in `release_notes.md`
 
 3. **Post-Release**

--- a/plans/_reference/CHANGELOG.md
+++ b/plans/_reference/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Sentient.io Interactive Presentation project will be 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version Status
+
+| Version | Status      |
+|---------|-------------|
+| V0.2.7  | In Progress |
+| V0.2.6  | Completed   |
+| V0.2.5  | Completed   |
+| V0.2.4  | Completed   |
+| V0.2.3  | Completed   |
+| V0.2.2  | Completed   |
+| V0.2.1  | Completed   |
+| V0.2.0  | Completed   |
+
 
 ## Version History
 

--- a/plans/_templates/create_version.md
+++ b/plans/_templates/create_version.md
@@ -84,7 +84,7 @@ Each version directory tracks progress through these stages in `TASKS.md`:
 2. **In Progress** (Starts at Phase 3)
 3. **Completed** (After Phase 6)
 
-The status is automatically updated during phase transitions and includes timestamps for each state change.
+The status is automatically updated during phase transitions and includes timestamps for each state change. A central Version Status table in `plans/_reference/CHANGELOG.md` lists all versions and their status—remember to update this table accordingly.
 
 ### Example status section in TASKS.md:
 ```markdown
@@ -437,7 +437,7 @@ For each key feature or deliverable outlined in `VERSION_PLAN.md` and `ROADMAP.m
 -   **`VERSION_PLAN.md`**: Checkboxes for specific feature implementation milestones are marked.
 -   **Code files** (e.g., `index.html`, `src/js/script.js`): Modified with new code.
 -   **`learn.log`**: AI can log *brief, critical* learnings related to specific implementation challenges immediately, but phase-wide reflections are deferred.
--   **Deferred Documentation**: Updates to `CHANGELOG.md`, overall phase progress in `TASKS.md`, `completion_checklist.md` (for phase completion), and comprehensive `learn.log` entries are deferred to Phase 4.
+-   **Deferred Documentation**: Updates to `CHANGELOG.md`—including the Version Status table, overall phase progress in `TASKS.md`, `completion_checklist.md` (for phase completion), and comprehensive `learn.log` entries are deferred to Phase 4.
 
 ## Learning & Reflection (Automated - Iterative during this Phase)
 ```
@@ -491,7 +491,7 @@ For each key feature or deliverable outlined in `VERSION_PLAN.md` and `ROADMAP.m
 3.  **`completion_checklist.md`**:
     *   Mark all high-level items (e.g., '[x] All Core Features Implemented', '[x] Testing Phase Passed', '[x] Documentation Complete', '[x] Final Review Approved') as complete.
 4.  **`CHANGELOG.md`**:
-    *   Add a comprehensive entry for the version, detailing all new features, changes, and fixes.
+    *   Update the Version Status table and add a comprehensive entry for the version, detailing all new features, changes, and fixes.
 5.  **`RELEASE_NOTES.md`**:
     *   Draft or finalize release notes, including new features, known issues (if any), and test results summary.
 6.  **`learn.log`**:


### PR DESCRIPTION
## Summary
- mention the central Version Status table in the version creation template
- update instructions for adding changelog entries to also update the status table
- sync V0.2.6 create_version.md with the new instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844df86977c83298bf453255c1f21e8