### PR TITLE
Remove obsolete coding standards reference

### DIFF
--- a/plans/_reference/product_management.md
+++ b/plans/_reference/product_management.md
@@ -149,7 +149,7 @@ The standard subdirectories within `plans/` are:
         *   `ROADMAP.md`: High-level overview of the project's long-term vision and planned major versions/features.
         *   `CHANGELOG.md`: A log of all notable changes made to the project, typically organized by version.
         *   `product_management.md`: This document itself, outlining the project management processes.
-        *   `coding_standards.md`, `style_guide.md`, etc.
+        *   `content/style.md`, etc.
     *   **File Naming**: Descriptive kebab-case names.
 
 *   **`_templates/`**:
@@ -194,7 +194,7 @@ Each version directory in `1_planning/` should include:
 
 **Directory Naming**: Use semantic versioning (e.g., `V1.0.0`)
 
-        *   `coding_standards.md`, `style_guide.md`, etc.
+        *   `content/style.md`, etc.
     *   **File Naming**: Descriptive kebab-case names.
 
 *   **`_templates/`**:


### PR DESCRIPTION
## Summary
- update product_management docs to use `content/style.md` instead of non-existent style_guide.md
- drop mention of coding_standards.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455b6438148329919b96c24fab5317