### PR TITLE
Remove RELEASE_NOTES from planning docs

### DIFF
--- a/plans/_reference/CHANGELOG.md
+++ b/plans/_reference/CHANGELOG.md
@@ -102,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `plans/_reference/ROADMAP.md` to mark V0.2.6 as 'Completed'.
 - Updated status in `plans/1_planning/V0.2.6/TASKS.md` to 'Completed'.
-- Finalized `plans/1_planning/V0.2.6/VERSION_PLAN.md` and `plans/1_planning/V0.2.6/RELEASE_NOTES.md`.
+- Finalized `plans/1_planning/V0.2.6/VERSION_PLAN.md`.
 
 ## [V0.2.5] - 2025-06-05
 

--- a/plans/_reference/code_verification.md
+++ b/plans/_reference/code_verification.md
@@ -18,11 +18,6 @@ Created in: `plans/1_planning/VX.Y.Z/` (where X.Y.Z is the version number)
   - API documentation
   - Design constraints and dependencies
 
-- `RELEASE_NOTES.md`
-  - Version highlights
-  - New features and changes
-  - Known issues
-  - Upgrade instructions
 
 - `create_version.md` (copied from template)
   - Version-specific execution plan

--- a/plans/_reference/product_management.md
+++ b/plans/_reference/product_management.md
@@ -70,7 +70,6 @@ Upon receiving the instruction, the AI assistant will perform the following auto
 *   **Populate Directory with Standard Planning Files**: The AI will populate this new directory with a minimal set of files needed to manage the version's lifecycle:
     *   `VERSION_PLAN.md`: This is the main guide for the new version. It is created by copying the content from `plans/_templates/create_version.md`.
     *   `TECH_SPEC.md`: For detailing technical specifications, architecture, and requirements.
-    *   `RELEASE_NOTES.md`: To be filled with release notes and test results.
 *   **Implementation Planning**: OpenAI Codex manages tasks directly from `ROADMAP.md` and `TECH_SPEC.md`, so no `TASKS.md` file is created.
 *   **Populate `VERSION_PLAN.md`**: The AI will then populate the `VERSION_PLAN.md` in the new version directory with specific details (like version number, objectives) extracted from `plans/_reference/ROADMAP.md`.
 
@@ -185,7 +184,6 @@ Only the main app versions are listed in the changelog; individual commits may n
 ## Version Documentation
 
 Each version directory in `1_planning/` should include:
-- `RELEASE_NOTES.md` - Specific to that version
 
 **Directory Naming**: Use semantic versioning (e.g., `V1.0.0`)
 
@@ -455,8 +453,7 @@ When executed, this template will create and manage the following structure:
 ```
 plans/1_planning/VX.Y.Z/
 ├── VERSION_PLAN.md    # Version planning guide
-├── TECH_SPEC.md       # Technical specifications
-└── RELEASE_NOTES.md   # Release notes and test results
+└── TECH_SPEC.md       # Technical specifications
 ```
 
 #### Key Features

--- a/plans/_templates/create_version.md
+++ b/plans/_templates/create_version.md
@@ -216,7 +216,6 @@ Where type is one of: feat, fix, docs, style, refactor, test, chore
 - Ensure the following files exist in the version directory:
   - `VERSION_PLAN.md`: Version overview, goals (from ROADMAP.md), and high-level progress checkboxes.
   - `TECH_SPEC.md`: Technical specifications including design, architecture, API documentation, and implementation details.
-  - `RELEASE_NOTES.md`: Release notes and test results.
   - Initialize `VERSION_PLAN.md` with unchecked checkboxes for all defined high-level sections.
 
 ### 1.3 Validation
@@ -231,7 +230,6 @@ Where type is one of: feat, fix, docs, style, refactor, test, chore
 plans/1_planning/VX.Y.Z/
 ├── VERSION_PLAN.md   # Version overview, goals, and high-level design
 ├── TECH_SPEC.md      # Technical specs, architecture, and requirements
-├── RELEASE_NOTES.md  # Release notes and test results
 ```
 
 ### File Descriptions:
@@ -248,12 +246,6 @@ plans/1_planning/VX.Y.Z/
    - Design constraints
    - Dependencies
 
-3. **RELEASE_NOTES.md**
-   - Release summary
-   - New features and changes
-   - Known issues
-   - Test results summary
-   - Upgrade instructions
 
 ## Actions (Automated)
 1. Set up version control branch
@@ -420,9 +412,7 @@ For each key feature or deliverable outlined in `VERSION_PLAN.md` and `ROADMAP.m
     *   Mark all high-level items (e.g., '[x] All Core Features Implemented', '[x] Testing Phase Passed', '[x] Documentation Complete', '[x] Final Review Approved') as complete.
 4.  **`CHANGELOG.md`**:
     *   Update the Version Status table and add a comprehensive entry for the version, detailing all new features, changes, and fixes.
-5.  **`RELEASE_NOTES.md`**:
-    *   Draft or finalize release notes, including new features, known issues (if any), and test results summary.
-6.  **`learn.log`**:
+5.  **`learn.log`**:
     *   Append a consolidated summary of learnings from the entire Phase 3 (all features) and from this Phase 4.
     *   Example structure for consolidated Phase 3 learnings:
         ```

--- a/plans/_templates/do_plan.md
+++ b/plans/_templates/do_plan.md
@@ -25,7 +25,6 @@
   - Create standard files in the new directory:
     - `VERSION_PLAN.md`: Version overview, goals, and high-level design
     - `TECH_SPEC.md`: Technical specifications and architecture
-    - `RELEASE_NOTES.md`: Release notes and test results
   - Copy templates:
     - Use `plans/_templates/create_version.md` as the initial content for `VERSION_PLAN.md`
 
@@ -79,7 +78,6 @@
 3. **Post-Execution**
    - Verify all changes were applied
    - Update ROADMAP.md and CHANGELOG.md
-   - Generate execution summary in `RELEASE_NOTES.md`
    - Log completion status to `run.log` (planned feature)
 
 ## Error Handling & Logging


### PR DESCRIPTION
## Summary
- remove references to `RELEASE_NOTES.md` in planning templates and docs

## Testing
- `node testing/check_unique_ids.js`

------
https://chatgpt.com/codex/tasks/task_e_6845d31e37788329b90ba373ba887239