### PR TITLE
Update do_plan template

### DIFF
--- a/plans/_templates/do_plan.md
+++ b/plans/_templates/do_plan.md
@@ -4,12 +4,12 @@ Follow these steps in order. Mark each step as complete when finished.
 
 1. [ ] **Validate Prerequisites**
    - Confirm `plans/_reference/ROADMAP.md` exists
-   - Ensure git is initialized and credentials are configured
-   - Verify write permissions in the repository
+   - Ensure the environment is ready for file creation
+   - Verify you have write permissions
 
 2. [ ] **Create Version Directory**
    - Determine the next version number from ROADMAP
-   - Make `plans/1_planning/VX.Y.Z/`
+   - Make `plans/Versions/VX.Y.Z/`
    - Copy `plans/_templates/create_version.md` to `VERSION_PLAN.md`
    - Copy `plans/_templates/TECH_SPEC.md` to `TECH_SPEC.md`
 
@@ -23,9 +23,9 @@ Follow these steps in order. Mark each step as complete when finished.
 
 5. [ ] **Execute Version Plan Phases**
    - Follow each phase in `VERSION_PLAN.md`
-   - Commit changes after completing a phase
+   - Record progress after completing a phase
 
 6. [ ] **Finalize Version Setup**
    - Run automated checks and apply fixes if needed
    - Mark the version "Ready for Release" in ROADMAP
-   - Make a final commit summarizing all changes
+   - Add a final summary of all changes


### PR DESCRIPTION
## Summary
- clarify environment prerequisites
- create versions under `plans/Versions` instead of `1_planning`
- remove git-specific language

## Testing
- `node testing/check_unique_ids.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68463048ab288329acc3b3b3852c3213