### PR TITLE
Fix documentation for four-phase workflow

### DIFF
--- a/plans/_reference/code_verification.md
+++ b/plans/_reference/code_verification.md
@@ -3,7 +3,7 @@
 ### Files Created by do_plan.md and create_version.md
 
 ### 1. Version Directory Structure
-Created in: `plans/1_planning/VX.Y.Z/` (where X.Y.Z is the version number)
+Created in: `plans/Versions/VX.Y.Z/` (where X.Y.Z is the version number)
 
 ### 2. Core Documentation Files
 - `VERSION_PLAN.md`
@@ -29,7 +29,6 @@ Created in: `plans/1_planning/VX.Y.Z/` (where X.Y.Z is the version number)
   - `finish_version.md` (completion guide)
   - Documentation update instructions
   - ROADMAP.md and CHANGELOG.md update procedures
-  - Directory movement instructions from `1_planning/` to `Versions/`
   - Project parameters
 
 ### 5. Referenced and Updated Files
@@ -49,12 +48,12 @@ Created in: `plans/1_planning/VX.Y.Z/` (where X.Y.Z is the version number)
 ## 2. What are the phases in create_version.md?
 
 
-`create_version.md` contains the following 4 phases:
+`create_version.md` outlines a four-phase workflow from planning through finalization:
 
 1. **Phase 1: Comprehensive Planning & Design (Automated)**
    - Version information extraction from ROADMAP.md
    - Standard files setup in the version directory
-   - Automated task list generation in TASKS.md
+   - Automated task checklist generation within VERSION_PLAN.md
    - Validation of requirements and dependencies
 
 2. **Phase 2: Development Kickoff**
@@ -65,7 +64,7 @@ Created in: `plans/1_planning/VX.Y.Z/` (where X.Y.Z is the version number)
 
 3. **Phase 3: Iterative Feature Development & Implementation**
    - Code impact analysis with granular task creation
-   - Implementation of tasks from TASKS.md
+   - Implementation of tasks tracked in VERSION_PLAN.md
    - HTML and JavaScript updates for slides
    - Verification of slide architecture and navigation
 
@@ -77,22 +76,20 @@ Created in: `plans/1_planning/VX.Y.Z/` (where X.Y.Z is the version number)
 
 Each phase includes:
 - Required file updates
-- Progress tracking in TASKS.md
-- Learning capture for continuous improvement
+- Progress tracking in VERSION_PLAN.md
 - Documentation updates
-- Automated logging to learn.log
 
-## 3. Are the tasks in tasks.md that create_version.md creates executed?
+## 3. Are the tasks tracked in VERSION_PLAN.md executed?
 
-Yes, tasks in `tasks.md` are executed during Phase 3 (Implementation) of `create_version.md`. Here's how it works:
+Yes, tasks in the checklist within `VERSION_PLAN.md` are executed during Phase 3 (Implementation) of `create_version.md`. Here's how it works:
 
 1. **Task Generation**
-   - Tasks are defined in `TASKS.md` during earlier phases
+   - Tasks are defined in the checklist in `VERSION_PLAN.md` during earlier phases
    - Each task is tracked by status
    - Tasks reference requirements and specifications in `TECH_SPEC.md`
 
 2. **Task Execution**
-   - Tasks are executed in the order they appear in `tasks.md`
+   - Tasks are executed in the order they appear in the checklist
    - Updates to task status are made upon completion
    - Progress is tracked throughout the implementation
 
@@ -102,9 +99,9 @@ Yes, tasks in `tasks.md` are executed during Phase 3 (Implementation) of `create
    - Changes are committed with descriptive messages
 
 4. **Status and Logging**
-   - Task status and overall progress are tracked in `TASKS.md`
-   - Execution details and issues are logged in `learn.log`
-   - Both files are updated during implementation
+   - Task status and overall progress are tracked in `VERSION_PLAN.md`
+   - Execution details are documented alongside the checklist
+   - Progress is updated directly within `VERSION_PLAN.md`
 
 5. **HTML Structure Verification**
    - Slide structure is verified for consistency
@@ -131,7 +128,7 @@ Yes, a critical early task, referred to as "Initial Code Analysis" (and specifie
     *   Dependencies and impacts
     *   Slide architecture considerations
 
-3.  **Task Generation**: Based on this analysis, `TASKS.md` is populated with granular tasks for the implementation phase, ensuring proper slide integration and consistency.
+3.  **Task Generation**: Based on this analysis, the checklist in `VERSION_PLAN.md` is populated with granular tasks for the implementation phase, ensuring proper slide integration and consistency.
 
 This approach ensures code changes are properly planned and documented before full implementation, providing a clear roadmap for the development process while focusing on the HTML-based slide architecture.
 
@@ -155,7 +152,7 @@ Yes, both `do_plan.md` and `create_version.md` are designed to run automatically
 3. **Phase-based Execution**:
    - `create_version.md` follows a strict phase-based approach
    - Each phase validates its own requirements before proceeding
-   - Status is tracked in `TASKS.md`
+   - Status is tracked in `VERSION_PLAN.md`
    - Progress is logged for monitoring
 
 4. **Error Handling**:
@@ -165,49 +162,23 @@ Yes, both `do_plan.md` and `create_version.md` are designed to run automatically
 
 5. **Logging and Status**:
    - All operations are logged for audit purposes
-   - Status is tracked in `TASKS.md`
-   - Learnings are captured in `learn.log` for continuous improvement
+   - Status is tracked in `VERSION_PLAN.md`
 
 This fully automated approach ensures consistent and reliable version management while eliminating the need for manual intervention during execution.
 
-## 6. Where are learn.log used for logging in do_plan.md and create_version.md?
+## 6. Does the workflow still use learn.log?
 
-### learn.log Usage in current 4-phase implementation:
-
-1. **In do_plan.md**:
-   - Used to document key learnings during execution
-   - Captured in the "Update Project Files" phase
-
-2. **In create_version.md** (following its 4-phase operational model):
-   - Captures learnings throughout the version creation process, recorded in `learn.log`.
-   - **Phase 1 (Comprehensive Planning & Design - Automated):** While this phase doesn't have its own direct "Learning & Reflection" section, its learnings are conceptually captured and then explicitly appended to `learn.log` during Phase 2.
-   - **Phase 2 (Development Kickoff):**
-     - Appends learnings from Phase 1 to `learn.log`.
-     - Appends its own "Phase 2 Learnings" (from its "Learning & Reflection" section) to `learn.log`.
-   - **Phase 3 (Iterative Feature Development & Implementation):**
-     - Allows for *brief, critical* learnings related to specific implementation challenges to be logged iteratively to `learn.log` as they occur.
-     - A comprehensive summary of all Phase 3 learnings is deferred and logged by Phase 4.
-   - **Phase 4 (Holistic Review, Testing, Documentation & Finalization):**
-     - Appends a consolidated summary of all learnings from the entire Phase 3 to `learn.log`.
-     - Appends its own "Phase 4 Learnings" (from its "Learning & Reflection" section) to `learn.log`.
-   - Focus is on documenting code structure and HTML application modifications.
-
-### Implementation Notes:
-- `learn.log` is actively used for continuous improvement
-- The log helps maintain context between different phases of execution
-- Focus is on documenting code quality and HTML structure improvements
-- Captures insights for slide architecture management and navigation consistency
+The updated `product_management.md` does not mention a `learn.log` file. Previous workflows stored learning notes in this log between phases, but its use is now optional.
 
 
 ## 7. Are the files mentioned in Q1 the only ones created by do_plan.md and create_version.md?
 
 Yes, the files mentioned in Q1 represent a comprehensive list of all files and directories created by `do_plan.md` and `create_version.md`. The list in Q1 has been updated to include:
 
-- Core documentation files (`VERSION_PLAN.md`, `TASKS.md`, etc.)
+- Core documentation files (`VERSION_PLAN.md`, etc.)
 - The copied template files (`create_version.md` in the version directory)
 - Supporting directories (`docs/`, `testing/results/`)
 - Configuration files (copied or created during initialization)
-- Log file (`learn.log`)
 
 The files listed under "Referenced and Updated Files" in Q1 (such as `.github/workflows/`, `.gitignore`, and `CHANGELOG.md`) are not created by these templates but are only referenced or updated during the process.
 
@@ -236,43 +207,6 @@ The following files are referenced in the workflow but not created by either `do
    - `.gitignore` - Git ignore configuration.
    - `CHANGELOG.md` - Release history (updated with new version details).
 
-### Clarification on Log Files:
-- `learn.log` is created by the templates, not just referenced, so it is correctly listed in Q1 under "Log Files"
+### Additional Notes
 
-## 9. How does the learning and reflection mechanism work across phases in create_version.md?
-
-`create_version.md` implements a continuous learning cycle across all phases:
-
-1. **Learning at the End of Each Phase**:
-   - Phases 2-4 include dedicated "Learning & Reflection" sections
-   - Phase 1 has its learnings explicitly appended by Phase 2
-   - Learnings are saved to `learn.log`
-   - Structured format generally includes:
-     - What Went Well
-     - Challenges Faced
-     - Key Insights
-
-2. **Reading Learnings at Phase Start**:
-   - Phases 2-4 include a "Learning from Previous Phases" section
-   - Phase 4 also includes this placeholder section
-   - References reading from `learn.log`
-   - Placeholder: `[Previous phases' learnings will be automatically inserted here from learn.log]`
-
-3. **Automated File Updates**:
-   - All phases include appending to `learn.log` in their "File Updates" sections
-   - Phase 1's learnings are explicitly appended by Phase 2
-   - Example: `Append Phase X learnings to learn.log`
-
-4. **Varied but Consistent Structure**:
-   - Core learning capture and logging mechanisms are present for all phases
-   - The pattern of reading and writing learnings is maintained throughout
-   - Creates a feedback loop between phases
-
-5. **Implementation**:
-   - Learnings are timestamped and categorized by phase
-   - The system maintains a running log in `learn.log`
-   - Each phase builds upon learnings from previous ones
-
-This mechanism ensures knowledge is captured, stored, and applied throughout the version management process, creating a continuous improvement cycle.
-
-
+The updated guide no longer references a dedicated `learn.log` file. Earlier templates used this log to capture learning and reflection at each phase. Teams may still record insights if desired, but it is not required.


### PR DESCRIPTION
## Summary
- update code_verification.md to reference the four-phase flow in create_version.md
- remove outdated note about additional phases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684659d852e08329bf3361c91ba78b6a