### PR TITLE
Remove learn.log use from templates

### DIFF
--- a/plans/_reference/code_verification.md
+++ b/plans/_reference/code_verification.md
@@ -166,9 +166,9 @@ Yes, both `do_plan.md` and `create_version.md` are designed to run automatically
 
 This fully automated approach ensures consistent and reliable version management while eliminating the need for manual intervention during execution.
 
-## 6. Does the workflow still use learn.log?
+## 6. How are learnings recorded?
 
-The updated `product_management.md` does not mention a `learn.log` file. Previous workflows stored learning notes in this log between phases, but its use is now optional.
+The workflow no longer uses a `learn.log` file. All learning notes are stored directly in `VERSION_PLAN.md` at the end of each phase.
 
 
 ## 7. Are the files mentioned in Q1 the only ones created by do_plan.md and create_version.md?
@@ -209,4 +209,4 @@ The following files are referenced in the workflow but not created by either `do
 
 ### Additional Notes
 
-The updated guide no longer references a dedicated `learn.log` file. Earlier templates used this log to capture learning and reflection at each phase. Teams may still record insights if desired, but it is not required.
+The updated guide no longer uses a dedicated `learn.log` file. Learnings are instead recorded in `VERSION_PLAN.md` after each phase. Teams may maintain additional logs if desired, but they are optional.

--- a/plans/_templates/create_version.md
+++ b/plans/_templates/create_version.md
@@ -32,7 +32,7 @@
 - [ ] Review milestones and targets
 - [ ] Populate `VERSION_PLAN.md` and `TECH_SPEC.md`
 - [ ] Verify dependencies and resources
-- [ ] Record Phase 1 learnings in `learn.log`
+ - [ ] Record Phase 1 learnings in `VERSION_PLAN.md`
 - [ ] Update status checkboxes
 
 ### 4.3 Phase 3: Iterative Feature Development & Implementation
@@ -41,7 +41,7 @@
 - [ ] Perform developer testing
 - [ ] Commit frequently using `feat(scope): description`
 - [ ] Mark feature progress in `VERSION_PLAN.md`
-- [ ] Log key learnings in `learn.log`
+ - [ ] Log key learnings in `VERSION_PLAN.md`
 
 ### 4.4 Phase 4: Holistic Review, Testing, Documentation & Finalization
 - [ ] Run automated code checks and peer review

--- a/plans/_templates/do_plan.md
+++ b/plans/_templates/do_plan.md
@@ -44,7 +44,7 @@
    - [ ] Update `plans/_reference/ROADMAP.md` with new version details and status
    - [ ] Add new version section to `plans/_reference/CHANGELOG.md`
    - [ ] Ensure all standard files are complete and consistent
-   - [ ] Document key learnings in `learn.log`
+  - [ ] Document key learnings in `VERSION_PLAN.md`
    - [ ] Commit all changes with descriptive messages following the format:
      ```
      type(scope): concise description


### PR DESCRIPTION
## Summary
- replace learn.log references with VERSION_PLAN.md in do_plan template
- clarify learning storage in code_verification reference
- ensure versioned directories remain untouched

## Testing
- `node testing/check_unique_ids.js`


------
https://chatgpt.com/codex/tasks/task_e_68467e7991bc83299e1aad4617510caf