### PR TITLE
Remove references to deprecated planning files

### DIFF
--- a/plans/_reference/product_management.md
+++ b/plans/_reference/product_management.md
@@ -41,62 +41,6 @@ To complete a version and mark it as done, follow these steps:
    - The version will appear in the "Recent Releases" section of ROADMAP.md
    - The version directory will be in `plans/Versions/` for reference
 
-## Detailed Steps for Starting a New Version
-
-To start the development of the next app version, follow these steps, which involve both manual preparation and AI-assisted automation:
-
-**1. Prerequisites (Manual Setup)**
-
-Before initiating the automated process, you need to prepare two key files:
-
-*   **Update `plans/_reference/ROADMAP.md`**:
-    *   Ensure the `ROADMAP.md` file is updated with the details for the new version. This includes:
-        *   The new version number (e.g., V0.3.0).
-        *   The target date for the version release.
-        *   A clear list of key deliverables and objectives for this version.
-    *   The AI assistant will read from this file to understand the scope and details of the new version.
-
-
-**2. Initiating the Process (User Action)**
-
-*   To begin, instruct your AI assistant (e.g., Jules) to: **"Execute `do_plan.md`"**.
-*   `do_plan.md` is a master script template located at `plans/_templates/do_plan.md` that orchestrates the setup of the new version.
-
-**3. Automated Setup (AI Execution of `do_plan.md`)**
-
-Upon receiving the instruction, the AI assistant will perform the following automated steps by executing the logic within `do_plan.md`:
-
-*   **Review `ROADMAP.md`**: The AI first checks `plans/_reference/ROADMAP.md` to identify the next planned version, its target date, and key deliverables.
-*   **Create Version-Specific Directory**: A new directory for the version will be created in `plans/Versions/`, following a naming convention like `plans/Versions/VX.Y.Z/` (where X.Y.Z is the new version number).
-*   **Populate Directory with Standard Planning Files**: The AI will populate this new directory with a minimal set of files needed to manage the version's lifecycle:
-    *   `VERSION_PLAN.md`: This is the main guide for the new version. It is created by copying the content from `plans/_templates/create_version.md`.
-    *   `TECH_SPEC.md`: For detailing technical specifications, architecture, and requirements.
-*   **Implementation Planning**: Tasks are tracked as a numbered checklist directly inside `VERSION_PLAN.md`.
-*   **Populate `VERSION_PLAN.md`**: The AI will then populate the `VERSION_PLAN.md` in the new version directory with specific details (like version number, objectives) extracted from `plans/_reference/ROADMAP.md`.
-
-**4. Starting the Development Workflow (AI Execution of `VERSION_PLAN.md`)**
-
-*   Once the setup is complete, the AI assistant will automatically begin executing Phase 1 of the newly created `VERSION_PLAN.md` (which is the content from `plans/_templates/create_version.md`) within the new version's directory (e.g., `plans/Versions/VX.Y.Z/VERSION_PLAN.md`).
-*   This `VERSION_PLAN.md` outlines a four-phase workflow for the new version:
-    *   Phase 1: Comprehensive Planning & Design
-    *   Phase 2: Development Kickoff
-    *   Phase 3: Iterative Feature Development & Implementation
-    *   Phase 4: Holistic Review, Testing, Documentation & Finalization
-*   The AI will follow the instructions within this `VERSION_PLAN.md`, guided by information from `ROADMAP.md` and `TECH_SPEC.md`, to manage the development lifecycle.
-
-**5. Project File Updates (Automated)**
-
-Throughout this process, several key project files are updated automatically:
-
-*   `plans/_reference/ROADMAP.md`:
-    *   The status of the new version will be updated to 'In Planning' during Phase 1 of `VERSION_PLAN.md`.
-    *   Later, it will be updated with the completion status upon release.
-*   `plans/_reference/CHANGELOG.md`: A new section for the version will be added to the `CHANGELOG.md` to document changes as development progresses and upon release.
-
-By following these steps, the development process for a new application version is systematically initiated, leveraging automation to ensure consistency and adherence to the defined project management structure.
----
-This guide is based on the information found in `README.md`, `plans/_templates/create_version.md`, and `plans/_templates/do_plan.md`.
-
 ## Introduction
 
 Welcome to the Sentient.io Interactive Presentation project management guide. This document provides a structured approach to managing our development process, ensuring consistency, quality, and effective collaboration between team members and AI assistants.
@@ -121,8 +65,6 @@ sentient-BP/
 ├── plans/                   # Project management documents
 │   ├── Versions/           # Version directories
 │   │   └── VX.Y.Z/        # Active and completed versions
-│   ├── _reference/         # Reference materials
-│   └── _templates/         # Document templates
 ├── src/                    # Source code
 ├── static/                 # Static assets (CSS, images, etc.)
 ├── templates/              # HTML templates
@@ -133,31 +75,10 @@ sentient-BP/
 
 The `plans/` directory is central to our project management methodology. It provides a structured way to track ideas, plan upcoming work, manage ongoing tasks, and archive completed efforts. Adhering to a standardized organization within `plans/` ensures clarity and allows for easy replication of our project management processes across different projects.
 
-The standard subdirectories within `plans/` are:
-*   **`Versions/`**:
-    *   **Purpose**: Contains a directory for each version of the application, regardless of its status (planning, in progress, or completed).
-    *   **Content**: Organized into version-specific subdirectories (e.g., `V1.0.0/`, `V1.1.0_feature-name/`). Each subdirectory should contain:
-        *   `README.md`: An overview of the version/feature, its goals, and key deliverables.
-        *   `TECH_SPEC.md`: Technical specifications, including architecture, data models, API changes, and impact on existing systems.
-        *   Other relevant planning documents as needed.
-    *   **Directory Naming**: Use semantic versioning for general releases (e.g., `V1.0.0`, `V1.1.0`, `V2.0.0`). For feature-specific planning that might span multiple minor versions or is a significant standalone piece of work, consider `VMAJOR.MINOR_feature-name/` (e.g., `V1.2_search-implementation/`).
-    *   **File Naming**: Use standard names like `README.md` and `TECH_SPEC.md`. For other documents, use descriptive kebab-case.
-
-*   **`_reference/`**:
-    *   **Purpose**: Stores general project reference materials that are not tied to a specific version or feature lifecycle but are relevant for the overall project.
-    *   **Content**: Examples include:
-        *   `ROADMAP.md`: High-level overview of the project's long-term vision and planned major versions/features.
-        *   `CHANGELOG.md`: A log of all notable changes made to the project, typically organized by version.
-        *   `product_management.md`: This document itself, outlining the project management processes.
-        *   `content/style.md`, etc.
-    *   **File Naming**: Descriptive kebab-case names.
-
-*   **`_templates/`**:
-    *   **Purpose**: Contains standardized templates for various documents used in the project management process. This helps maintain consistency and ensures all necessary information is captured.
-    *   **Content**: Examples include:
-        *   `create_version.md`
-        *   `do_plan.md`
-    *   **File Naming**: Clearly indicate that it's a template.
+The standard subdirectory within `plans/` is:
+*   **`Versions/`**
+    *   Contains a directory for each version of the application.
+    *   Use semantic versioning for directory names (e.g., `V1.0.0`).
 
 This detailed structure, when consistently applied, will significantly improve project organization and knowledge sharing.
 
@@ -172,22 +93,11 @@ When a feature is finished, its details are added to the changelog and the roadm
 
 ## Version Documentation
 
-Each version directory in `plans/Versions/` should include:
+Each version directory in `plans/Versions/` contains the planning materials for that release.
 
-**Directory Naming**: Use semantic versioning (e.g., `V1.0.0`)
+**Directory Naming**: Use semantic versioning (e.g., `V1.0.0`).
 
-        *   `content/style.md`, etc.
-
-    *   **File Naming**: Descriptive kebab-case names.
-
-*   **`_templates/`**:
-    *   **Purpose**: Contains standardized templates for various documents used in the project management process. This helps maintain consistency and ensures all necessary information is captured.
-    *   **Content**: Examples include:
-        *   `create_version.md`
-        *   `do_plan.md`
-    *   **File Naming**: Clearly indicate that it's a template.
-
-This detailed structure, when consistently applied, will significantly improve project organization and knowledge sharing.
+This structure, when consistently applied, significantly improves project organization and knowledge sharing.
 ## Workflow
 
 1. Add upcoming features or ideas directly to `ROADMAP.md`.
@@ -235,18 +145,18 @@ All presentations must follow the McKinsey presentation standards defined in `co
 ### Feature and Version Tracking
 
 #### ROADMAP.md
-- **Location**: `plans/_reference/ROADMAP.md`
+- **Location**: `ROADMAP.md`
 - **Purpose**: Serves as the single source of truth for current and future development plans
 - **Contents**:
   - Upcoming versions with status and target dates
-  - Current focus with high-level deliverables (detailed tasks are maintained in `VERSION_PLAN.md`)
+  - Current focus with high-level deliverables
   - Planned features and improvements
   - Technical debt and future considerations
 - **Update Frequency**: During planning meetings and when priorities change
 - **Ownership**: Maintained by the product team with input from all stakeholders
 
 #### CHANGELOG.md
-- **Location**: `plans/_reference/CHANGELOG.md`
+- **Location**: `CHANGELOG.md`
 - **Purpose**: Records all notable changes made to the project
 - **Format**: Follows [Keep a Changelog](https://keepachangelog.com/) format
 - **Contents**:
@@ -373,80 +283,6 @@ The `content/` directory is the central repository for all presentation content 
    - Optimize images and assets
    - Minimize external dependencies
    - Implement lazy loading where appropriate
-
-## Templates & Examples
-
-### Starting a New Version (do_plan.md)
-
-To begin a new version planning process, simply tell your AI assistant:
-```
-Execute do_plan.md
-```
-
-**Location**: `plans/_templates/do_plan.md`
-
-**What it does**:
-- Automatically checks ROADMAP.md for the next version
-- Creates and initializes a new version directory
-- Guides you through each planning phase
-- Updates all necessary files (roadmap, changelog, etc.)
-- Handles version control commits
-
-**Requirements**:
-- AI assistant with file execution capabilities
-- Write access to the repository
-- Internet connection (for AI functionality)
-
-### Version Planning Template (create_version.md)
-
-The `create_version.md` template is a comprehensive guide for managing software versions throughout their entire lifecycle. It's designed to be used with AI assistance and follows a four-phase approach from planning to finalization.
-
-#### Location
-- Template: `plans/_templates/create_version.md`
-- Usage: Copy to `plans/Versions/VX.Y.Z/` when starting a new version
-
-#### Directory Structure Created
-When executed, this template will create and manage the following structure:
-
-#### Key Features
-- **AI-Assisted Execution**: Can be executed with a single command
-- **Phased Approach**: Four phases from planning to finalization
-- **Comprehensive Documentation**: Ensures all aspects are documented
-- **Version Control Ready**: Includes guidance for Git integration
-
-#### How to Use
-1. Copy the template to your version directory
-2. Run `Execute create_version.md` with your AI assistant
-3. Follow the interactive prompts
-4. The AI will handle file creation and updates
-
-
-### Feature Specification
-```markdown
-# [Feature Name]
-
-## Version Control
-
-### Commit Messages
-- Reference relevant prompt IDs or feature numbers
-- Include the version number in the commit message when applicable
-- Follow conventional commit message format: `type(scope): description`
-
-### Tags
-- Use semantic versioning (e.g., v0.2.3)
-- Tag main version releases with corresponding version numbers
-- Include release notes in the tag annotation
-
-### Branching Strategy
-- `main`: Production-ready code
-- `feature/*`: New features or significant changes
-- `fix/*`: Bug fixes
-- `docs/*`: Documentation updates
-
-### AI-Generated Code
-- Document which parts were AI-generated in commit messages
-- Include the prompt used in the commit message
-- Ensure all AI-generated code is reviewed before merging to main
 
 ## Requirements
 - [ ] Requirement 1


### PR DESCRIPTION
## Summary
- clean up `product_management.md` to only mention ROADMAP.md, CHANGELOG.md and the Versions directory
- drop outdated template instructions

## Testing
- `node testing/check_unique_ids.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850d80139e883299f5c09145c606cb3